### PR TITLE
Add support for device kwarg in astype, and add matching utility func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Remember to align the itemized text with the first line of an item within a list
     implementation of cross-process collective operations used by the CPU backend.
     Choices available are `'none'`(default), `'gloo'` and `'mpi'` (requires jaxlib 0.4.26).
     If set to `'none'`, cross-process collective operations are disabled.
+* New Features
+  * {func}`jax.numpy.astype` supports new `device` keyword argument.
 
 * Changes
   * {func}`jax.pure_callback`, {func}`jax.experimental.io_callback`

--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -25,6 +25,7 @@ from jax._src.lib import xla_client
 from jax._src.lib import xla_extension_version
 from jax._src.typing import Array, DLDeviceType
 from jax._src.sharding import Sharding
+from jax._src.numpy.util import _place_array
 
 DLPACK_VERSION = (0, 8)
 MIN_DLPACK_VERSION = (0, 5)
@@ -152,19 +153,6 @@ def to_dlpack(x: Array, stream: int | Any | None = None,
       f"version ({max_version}) was requested."
     )
 
-def _place_array(_arr, device, dlpack_device, copy):
-  if device and dlpack_device != device:
-    if copy is not None and not copy:
-      raise ValueError(
-        f"Specified {device=} which requires a copy since the source device "
-        f"is {repr(dlpack_device)}, however copy=False. Set copy=True or "
-        "copy=None to perform the requested operation."
-      )
-    else:
-      return device_put(_arr, device)
-  if copy:
-    return jnp.array(_arr, copy=True)
-  return _arr
 
 def _legacy_from_dlpack(dlpack, device: xla_client.Device | None = None,
                         copy: bool | None = None):
@@ -198,8 +186,7 @@ def _legacy_from_dlpack(dlpack, device: xla_client.Device | None = None,
 
   _arr = jnp.asarray(xla_client._xla.dlpack_managed_tensor_to_buffer(
       dlpack, cpu_backend, gpu_backend)) # type: ignore
-  dlpack_device, = _arr.devices()
-  return _place_array(_arr, device, dlpack_device, copy)
+  return _place_array(_arr, device, copy)
 
 def _from_dlpack(external_array, device: xla_client.Device | None = None,
                  copy: bool | None = None):
@@ -230,7 +217,7 @@ def _from_dlpack(external_array, device: xla_client.Device | None = None,
 
   _arr = jnp.asarray(xla_client._xla.dlpack_managed_tensor_to_buffer(
       dlpack, dlpack_device, stream))
-  return _place_array(_arr, device, dlpack_device, copy)
+  return _place_array(_arr, device, copy)
 
 def from_dlpack(external_array,
                 device: xla_client.Device | Sharding | None = None,

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2636,17 +2636,13 @@ def astype(x: ArrayLike, dtype: DTypeLike | None,
   # to issue our warning.
   with warnings.catch_warnings():
     warnings.simplefilter("ignore", ComplexWarning)
-    return _place_array(
+    return util._place_array(
       lax.convert_element_type(x_arr, dtype),
-      device=device, copy=copy,
+      device=device,
+      # We translate between array API semantics of copy in _place_array, and
+      # the NumPy semantics of copy in astype.
+      copy=True if copy else None,
     )
-
-def _place_array(x, device=None, copy=None):
-  # TODO(micky774): Implement in future PRs as we formalize device placement
-  # semantics
-  if copy:
-    return _array_copy(x)
-  return x
 
 
 @util.implements(np.asarray, lax_description=_ARRAY_DOC)


### PR DESCRIPTION
WIP

This branches off of the open branch which adds the `copy` kwarg to `astype` and is mainly meant to host discussion regarding the device transfer semantics for JAX in and out of JIT, as well as to develop common utilities for the rest of `jax.numpy` and `jax.experimental.array_api`